### PR TITLE
Handle async voice session shutdown errors

### DIFF
--- a/src/components/voice-agents/SophieAgentsSDK.tsx
+++ b/src/components/voice-agents/SophieAgentsSDK.tsx
@@ -208,7 +208,7 @@ export function SophieAgentsSDK({
       }
       
       if (sessionRef.current) {
-        stopVoiceAgent(sessionRef.current);
+        await stopVoiceAgent(sessionRef.current);
         sessionRef.current = null;
       }
       
@@ -237,6 +237,12 @@ export function SophieAgentsSDK({
       setIsConnecting(false);
       setIsSpeaking(false);
       setIsListening(false);
+
+      toast({
+        title: "Erreur fermeture",
+        description: error instanceof Error ? error.message : "Impossible d'arrêter la session",
+        variant: "destructive",
+      });
     }
   };
 

--- a/src/utils/VoiceAgentsSDK.ts
+++ b/src/utils/VoiceAgentsSDK.ts
@@ -49,13 +49,21 @@ export async function startVoiceAgent(instructions?: string): Promise<RealtimeSe
   }
 }
 
-export function stopVoiceAgent(session: RealtimeSession) {
+export async function stopVoiceAgent(session: RealtimeSession) {
+  console.log('🛑 Arrêt Voice Agent...');
+
   try {
-    console.log('🛑 Arrêt Voice Agent...');
-    // La session sera fermée automatiquement lors du démontage du composant
-    // ou via les méthodes internes du transport WebRTC
+    if (typeof session.disconnect === 'function') {
+      await session.disconnect();
+    } else if (typeof session.close === 'function') {
+      await session.close();
+    } else {
+      throw new Error("La session ne propose pas de méthode de fermeture compatible");
+    }
+
     console.log('✅ Voice Agent arrêté');
   } catch (error) {
     console.error('❌ Erreur lors de l\'arrêt:', error);
+    throw error;
   }
 }


### PR DESCRIPTION
## Summary
- make `stopVoiceAgent` asynchronous so it explicitly disconnects or closes the realtime session and bubbles failures
- await the SDK shutdown inside `SophieAgentsSDK.endSession` and surface toast feedback when stopping fails

## Testing
- npm install *(fails: npm ERR! 403 Forbidden - GET https://registry.npmjs.org/zod)*

------
https://chatgpt.com/codex/tasks/task_e_68d211914e38832cbbb8f718a1810773