### PR TITLE
Add voice presets and audio formats to realtime sessions

### DIFF
--- a/src/components/voice-agents/SophieAgentsSDK.tsx
+++ b/src/components/voice-agents/SophieAgentsSDK.tsx
@@ -174,7 +174,7 @@ export function SophieAgentsSDK({
       console.log('📝 Instructions EDHEC générées:', instructions.substring(0, 200) + '...');
 
       // Démarrer la session WebRTC via SDK simplifié
-      sessionRef.current = await startVoiceAgent(instructions);
+      sessionRef.current = await startVoiceAgent(instructions, selectedConversationType);
 
       // Configurer les événements
       setupEventHandlers(sessionRef.current);

--- a/supabase/functions/get-openai-key/index.ts
+++ b/supabase/functions/get-openai-key/index.ts
@@ -23,41 +23,101 @@ serve(async (req) => {
       });
     }
 
-    const { instructions } = await req.json().catch(() => ({}));
+    const { instructions, voicePreset } = await req.json().catch(() => ({}));
+
+    const selectedVoice = voicePreset === "rdv" ? "cedar" : "marin";
+    console.log(`🎙️ Préparation session avec voix "${selectedVoice}" pour preset "${voicePreset || 'cold-call'}"`);
     console.log('🔑 Génération token éphémère OpenAI WebRTC (septembre 2025)...');
     
-    const response = await fetch("https://api.openai.com/v1/realtime/client_secrets", {
-      method: "POST",
-      headers: {
-        "Authorization": `Bearer ${OPENAI_API_KEY}`,
-        "Content-Type": "application/json",
+    const baseSession: Record<string, unknown> = {
+      type: "realtime",
+      model: "gpt-realtime",
+      voice: selectedVoice,
+      modalities: ["text", "audio"],
+      turn_detection: {
+        type: "server_vad",
+        interrupt_response: true
       },
-      body: JSON.stringify({
-        session: {
-          type: "realtime",
-          model: "gpt-realtime",
-          voice: "alloy",
-          modalities: ["text", "audio"],
-          input_audio_format: "pcm16",
-          output_audio_format: "pcm16",
-          turn_detection: { type: "semantic_vad" },
-          instructions: instructions || "Assistant vocal pédagogique en temps réel pour BYSS VNS."
-        }
-      })
-    });
+      instructions: instructions || "Assistant vocal pédagogique en temps réel pour BYSS VNS."
+    };
+
+    const modernAudioOverrides: Record<string, unknown> = {
+      input_audio_format: {
+        type: "pcm16",
+        sample_rate: 16000,
+        channels: 1
+      },
+      output_audio_format: {
+        type: "opus",
+        container: "ogg",
+        sample_rate: 48000
+      }
+    };
+
+    const legacyAudioOverrides: Record<string, unknown> = {
+      input_audio_format: "pcm16",
+      output_audio_format: "pcm16"
+    };
+
+    const createSession = async (overrides: Record<string, unknown>, label: string) => {
+      console.log(`🧪 Tentative création session (${label})`);
+      const response = await fetch("https://api.openai.com/v1/realtime/client_secrets", {
+        method: "POST",
+        headers: {
+          "Authorization": `Bearer ${OPENAI_API_KEY}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          session: {
+            ...baseSession,
+            ...overrides
+          }
+        })
+      });
+      return response;
+    };
+
+    let response = await createSession(modernAudioOverrides, "opus/pcm16 recommandé");
+    let fallbackAttempted = false;
 
     if (!response.ok) {
       const text = await response.text();
-      console.error('❌ OpenAI error:', response.status, text);
-      return new Response(JSON.stringify({ error: "openai_error", status: response.status, body: text }), { 
-        status: 502,
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-      });
+      console.error('❌ OpenAI error (opus/pcm16):', response.status, text);
+
+      if (response.status >= 400 && response.status < 500) {
+        console.warn('⏪ Repli vers configuration PCM16 héritée (API non à jour ?)');
+        fallbackAttempted = true;
+        response = await createSession(legacyAudioOverrides, "pcm16 héritage");
+
+        if (!response.ok) {
+          const legacyText = await response.text();
+          console.error('❌ OpenAI error (pcm16 héritage):', response.status, legacyText);
+          return new Response(JSON.stringify({ error: "openai_error", status: response.status, body: legacyText }), {
+            status: 502,
+            headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+          });
+        }
+      } else {
+        return new Response(JSON.stringify({ error: "openai_error", status: response.status, body: text }), {
+          status: 502,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        });
+      }
     }
 
     const data = await response.json();
     console.log('✅ Réponse OpenAI:', data);
-    
+
+    const warnings = data?.warnings || data?.client_secret?.warnings;
+    if (warnings && ((Array.isArray(warnings) && warnings.length > 0) || typeof warnings === "string")) {
+      console.warn('⚠️ Avertissement OpenAI (fallback potentiel):', warnings);
+    }
+
+    const fallback = data?.client_secret?.metadata?.fallback_model || data?.client_secret?.metadata?.fallback;
+    if (fallback) {
+      console.warn('⚠️ Modèle de repli OpenAI détecté:', fallback);
+    }
+
     // Extraire ek de la réponse
     const ek = (data?.client_secret?.value || data?.value);
     if (typeof ek !== "string" || !ek.startsWith("ek_")) {
@@ -68,10 +128,14 @@ serve(async (req) => {
       });
     }
     
+    if (fallbackAttempted) {
+      console.warn('✅ Token obtenu après repli audio PCM16. Surveiller la mise à jour de l’API.');
+    }
+
     console.log('✅ Token éphémère généré:', ek);
-    return new Response(JSON.stringify({ value: ek }), { 
-      status: 200, 
-      headers: { ...corsHeaders, "Content-Type": "application/json" } 
+    return new Response(JSON.stringify({ value: ek, audioFormatFallback: fallbackAttempted }), {
+      status: 200,
+      headers: { ...corsHeaders, "Content-Type": "application/json" }
     });
 
   } catch (error) {


### PR DESCRIPTION
## Summary
- add a voicePreset option when starting the voice agent so the selected scenario reaches the edge function
- configure the edge function to map presets to Marin or Cedar, request the recommended audio formats, and enable server VAD turn detection
- warn when OpenAI returns fallback metadata or warnings to help monitor quality
- retry with a legacy PCM16 audio profile when the recommended opus format is rejected so the edge function still succeeds and surface the downgrade to the client

## Testing
- `npm run lint` *(fails: @eslint/js package marked invalid because network access forbids reinstalling the expected version)*

------
https://chatgpt.com/codex/tasks/task_e_68d21197fda8832ca570d909d3a5043b