### PR TITLE
Use shared voice agent model constant

### DIFF
--- a/shared/voiceAgentModel.ts
+++ b/shared/voiceAgentModel.ts
@@ -1,0 +1,1 @@
+export const VOICE_AGENT_MODEL = "gpt-realtime";

--- a/src/utils/VoiceAgentsSDK.ts
+++ b/src/utils/VoiceAgentsSDK.ts
@@ -1,5 +1,6 @@
 import { OpenAIRealtimeWebRTC } from "@openai/agents-realtime";
 import { supabase } from "@/integrations/supabase/client";
+import { VOICE_AGENT_MODEL } from "../../shared/voiceAgentModel";
 
 export async function startVoiceAgent(instructions?: string): Promise<OpenAIRealtimeWebRTC> {
   try {
@@ -32,7 +33,7 @@ export async function startVoiceAgent(instructions?: string): Promise<OpenAIReal
     console.log('🔗 Connexion WebRTC...');
     await webrtcTransport.connect({
       apiKey: ek,
-      model: "gpt-4o-realtime-preview-2024-12-17"
+      model: VOICE_AGENT_MODEL
     });
 
     console.log('✅ Voice Agent connecté avec succès');

--- a/supabase/functions/get-openai-key/index.ts
+++ b/supabase/functions/get-openai-key/index.ts
@@ -1,5 +1,6 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
+import { VOICE_AGENT_MODEL } from "../../../shared/voiceAgentModel.ts";
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -35,7 +36,7 @@ serve(async (req) => {
       body: JSON.stringify({
         session: {
           type: "realtime",
-          model: "gpt-realtime",
+          model: VOICE_AGENT_MODEL,
           voice: "alloy",
           modalities: ["text", "audio"],
           input_audio_format: "pcm16",


### PR DESCRIPTION
## Summary
- add a shared VOICE_AGENT_MODEL constant for the realtime voice model
- update the browser VoiceAgentsSDK to use the shared constant when connecting
- update the Supabase get-openai-key function to reuse the shared constant for client secrets requests

## Testing
- npm run build *(fails: vite not found before installing dependencies)*
- npm install *(fails: npm 403 when downloading zod)*

------
https://chatgpt.com/codex/tasks/task_e_68d29d3c3448832ca4d503bb0a1cae5b