### PR TITLE
Handle voice agent teardown

### DIFF
--- a/src/components/voice-agents/SophieAgentsSDK.tsx
+++ b/src/components/voice-agents/SophieAgentsSDK.tsx
@@ -200,18 +200,29 @@ export function SophieAgentsSDK({
    */
   const endSession = async () => {
     console.log('🔌 Fermeture session Voice Agents SDK...');
-    
+
     try {
       if (timerRef.current) {
         clearInterval(timerRef.current);
         timerRef.current = null;
       }
-      
-      if (sessionRef.current) {
-        stopVoiceAgent(sessionRef.current);
-        sessionRef.current = null;
+
+      const currentSession = sessionRef.current;
+      if (currentSession) {
+        try {
+          await stopVoiceAgent(currentSession);
+          sessionRef.current = null;
+        } catch (error) {
+          console.error('❌ Erreur teardown Voice SDK:', error);
+          sessionRef.current = null;
+          toast({
+            title: "Erreur fermeture",
+            description: "La déconnexion a rencontré un problème. Vous pouvez réessayer.",
+            variant: "destructive",
+          });
+        }
       }
-      
+
       setIsConnected(false);
       setIsConnecting(false);
       setIsSpeaking(false);


### PR DESCRIPTION
## Summary
- ensure the Voice Agents SDK teardown stops local and remote media tracks before disconnecting
- wait for the stop promise when ending a session and surface teardown errors to the UI

## Testing
- npm install *(fails: 403 Forbidden when downloading packages)*

------
https://chatgpt.com/codex/tasks/task_e_68d2e2117488832cae5fcea28e92bd71