### PR TITLE
Improve voice agent media lifecycle handling

### DIFF
--- a/src/components/voice-agents/SophieAgentsSDK.tsx
+++ b/src/components/voice-agents/SophieAgentsSDK.tsx
@@ -3,7 +3,13 @@ import { Card, CardContent } from "@/components/ui/card";
 import { TestButton } from "@/components/ui/test-button";
 import { Badge } from "@/components/ui/badge";
 import { useToast } from "@/hooks/use-toast";
-import { startVoiceAgent, stopVoiceAgent } from "@/utils/VoiceAgentsSDK";
+import {
+  startVoiceAgent,
+  stopVoiceAgent,
+  getVoiceAgentRemoteStream,
+  stopMediaStream,
+  VoiceAgentSession
+} from "@/utils/VoiceAgentsSDK";
 import { buildEDHECInstructions } from "@/lib/edhec-prompts";
 import { 
   Phone, 
@@ -78,7 +84,10 @@ export function SophieAgentsSDK({
   const [guardrailAlerts, setGuardrailAlerts] = useState<any[]>([]);
   const [nativeTranscripts, setNativeTranscripts] = useState<string>('');
   
-  const sessionRef = useRef<any | null>(null);
+  const sessionRef = useRef<VoiceAgentSession | null>(null);
+  const localStreamRef = useRef<MediaStream | null>(null);
+  const remoteStreamRef = useRef<MediaStream | null>(null);
+  const audioRef = useRef<HTMLAudioElement | null>(null);
   const startTimeRef = useRef<Date | null>(null);
   const timerRef = useRef<NodeJS.Timeout | null>(null);
 
@@ -166,7 +175,7 @@ export function SophieAgentsSDK({
       setIsConnecting(true);
       setHistory([]);
       setExchangeCount(0);
-      
+
       console.log('🚀 Démarrage Sophie EDHEC avec Voice Agents SDK...');
 
       // Obtenir les instructions EDHEC authentiques
@@ -175,9 +184,40 @@ export function SophieAgentsSDK({
 
       // Démarrer la session WebRTC via SDK simplifié
       sessionRef.current = await startVoiceAgent(instructions);
+      localStreamRef.current = sessionRef.current.localStream;
+
+      const transport = sessionRef.current.transport;
+      const remoteStream = getVoiceAgentRemoteStream(sessionRef.current);
+      remoteStreamRef.current = remoteStream;
+
+      if (audioRef.current) {
+        audioRef.current.srcObject = remoteStream ?? null;
+        if (remoteStream) {
+          audioRef.current.play().catch(error => {
+            console.warn('⚠️ Lecture audio distante impossible immédiatement:', error);
+          });
+        }
+      }
+
+      const peerConnection = (transport as unknown as { pc?: RTCPeerConnection; peerConnection?: RTCPeerConnection }).pc
+        ?? (transport as unknown as { pc?: RTCPeerConnection; peerConnection?: RTCPeerConnection }).peerConnection;
+
+      peerConnection?.addEventListener('track', () => {
+        if (!sessionRef.current) return;
+        const refreshedStream = getVoiceAgentRemoteStream(sessionRef.current);
+        remoteStreamRef.current = refreshedStream;
+        if (audioRef.current) {
+          audioRef.current.srcObject = refreshedStream ?? null;
+          if (refreshedStream) {
+            audioRef.current.play().catch(error => {
+              console.warn('⚠️ Lecture audio distante impossible après mise à jour de piste:', error);
+            });
+          }
+        }
+      });
 
       // Configurer les événements
-      setupEventHandlers(sessionRef.current);
+      setupEventHandlers(transport);
 
       toast({
         title: "✅ Connexion établie",
@@ -200,18 +240,29 @@ export function SophieAgentsSDK({
    */
   const endSession = async () => {
     console.log('🔌 Fermeture session Voice Agents SDK...');
-    
+
     try {
       if (timerRef.current) {
         clearInterval(timerRef.current);
         timerRef.current = null;
       }
-      
+
       if (sessionRef.current) {
         stopVoiceAgent(sessionRef.current);
         sessionRef.current = null;
       }
-      
+
+      stopMediaStream(localStreamRef.current);
+      stopMediaStream(remoteStreamRef.current);
+
+      localStreamRef.current = null;
+      remoteStreamRef.current = null;
+
+      if (audioRef.current) {
+        audioRef.current.pause();
+        audioRef.current.srcObject = null;
+      }
+
       setIsConnected(false);
       setIsConnecting(false);
       setIsSpeaking(false);
@@ -233,6 +284,14 @@ export function SophieAgentsSDK({
       console.error('❌ Erreur fermeture session:', error);
       // Force cleanup
       sessionRef.current = null;
+      stopMediaStream(localStreamRef.current);
+      stopMediaStream(remoteStreamRef.current);
+      localStreamRef.current = null;
+      remoteStreamRef.current = null;
+      if (audioRef.current) {
+        audioRef.current.pause();
+        audioRef.current.srcObject = null;
+      }
       setIsConnected(false);
       setIsConnecting(false);
       setIsSpeaking(false);
@@ -244,7 +303,7 @@ export function SophieAgentsSDK({
     if (sessionRef.current && isConnected) {
       try {
         // Utiliser l'interruption native du SDK Voice Agents
-        await sessionRef.current.interrupt();
+        await sessionRef.current.transport.interrupt();
         addToHistory('system', '🔇 Interruption réussie (Voice SDK)', 'system');
         setIsSpeaking(false);
         setIsListening(true);
@@ -269,7 +328,7 @@ export function SophieAgentsSDK({
     if (sessionRef.current && isConnected && textInput.trim()) {
       try {
         // Utiliser sendMessage du SDK Voice Agents
-        await sessionRef.current.sendMessage(textInput.trim());
+        await sessionRef.current.transport.sendMessage(textInput.trim());
         console.log('📤 Message texte envoyé (Voice SDK):', textInput);
         setTextInput('');
         
@@ -346,14 +405,18 @@ export function SophieAgentsSDK({
 
   if (!open) return null;
 
+  const audioElement = <audio ref={audioRef} autoPlay playsInline className="hidden" />;
+
   // Interface réduite
   if (isMinimized) {
     return (
-      <Card className="fixed bottom-4 right-4 w-60 shadow-xl border-2 z-50">
-        <CardContent className="p-3">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-2">
-              <div className={`w-6 h-6 rounded-full flex items-center justify-center text-xs ${
+      <>
+        {audioElement}
+        <Card className="fixed bottom-4 right-4 w-60 shadow-xl border-2 z-50">
+          <CardContent className="p-3">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <div className={`w-6 h-6 rounded-full flex items-center justify-center text-xs ${
                 isConnected 
                   ? isSpeaking 
                     ? 'bg-blue-100 animate-pulse' 
@@ -410,36 +473,39 @@ export function SophieAgentsSDK({
               )}
             </div>
           )}
-        </CardContent>
-      </Card>
+          </CardContent>
+        </Card>
+      </>
     );
   }
 
   // Interface principale
   return (
-    <Card className="fixed bottom-6 right-6 w-96 p-6 bg-card/95 backdrop-blur-sm border shadow-lg z-50">
-      <div className="space-y-4">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            <div className={`w-10 h-10 rounded-full flex items-center justify-center text-lg ${
-              isConnected 
-                ? isSpeaking 
-                  ? 'bg-blue-100 animate-pulse' 
-                  : 'bg-blue-50'
-                : 'bg-muted'
-            }`}>
-              👩‍💼
+    <>
+      {audioElement}
+      <Card className="fixed bottom-6 right-6 w-96 p-6 bg-card/95 backdrop-blur-sm border shadow-lg z-50">
+        <div className="space-y-4">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <div className={`w-10 h-10 rounded-full flex items-center justify-center text-lg ${
+                isConnected
+                  ? isSpeaking
+                    ? 'bg-blue-100 animate-pulse'
+                    : 'bg-blue-50'
+                  : 'bg-muted'
+              }`}>
+                👩‍💼
+              </div>
+              <div>
+                <span className="font-medium">Sophie Hennion-Moreau</span>
+                <p className="text-xs text-muted-foreground">Dir. Innovation Pédagogique • EDHEC</p>
+              </div>
             </div>
-            <div>
-              <span className="font-medium">Sophie Hennion-Moreau</span>
-              <p className="text-xs text-muted-foreground">Dir. Innovation Pédagogique • EDHEC</p>
-            </div>
+            <Badge variant="secondary" className="text-xs flex items-center gap-1">
+              <Zap className="w-3 h-3" />
+              Agents SDK
+            </Badge>
           </div>
-          <Badge variant="secondary" className="text-xs flex items-center gap-1">
-            <Zap className="w-3 h-3" />
-            Agents SDK
-          </Badge>
-        </div>
 
         {/* Status de connexion */}
         <div className="flex items-center justify-between">
@@ -613,7 +679,8 @@ export function SophieAgentsSDK({
             </TestButton>
           </div>
         )}
-      </div>
-    </Card>
+        </div>
+      </Card>
+    </>
   );
 }

--- a/src/utils/VoiceAgentsSDK.ts
+++ b/src/utils/VoiceAgentsSDK.ts
@@ -2,7 +2,13 @@ import { OpenAIRealtimeWebRTC } from "@openai/agents-realtime";
 import { supabase } from "@/integrations/supabase/client";
 import { VOICE_AGENT_MODEL } from "../../shared/voiceAgentModel";
 
-export async function startVoiceAgent(instructions?: string): Promise<OpenAIRealtimeWebRTC> {
+export interface VoiceAgentSession {
+  transport: OpenAIRealtimeWebRTC;
+  localStream: MediaStream | null;
+  remoteStream: MediaStream | null;
+}
+
+export async function startVoiceAgent(instructions?: string): Promise<VoiceAgentSession> {
   try {
     console.log('🎤 Démarrage Voice Agent SDK...');
     
@@ -29,6 +35,12 @@ export async function startVoiceAgent(instructions?: string): Promise<OpenAIReal
       apiKey: ek
     });
 
+    console.log('🎧 Initialisation des médias locaux...');
+    const requestedLocalStream = await webrtcTransport.startLocalMedia({ audio: true }).catch(error => {
+      console.error('❌ Impossible d\'initialiser le micro:', error);
+      throw error;
+    });
+
     // 3) Connexion WebRTC
     console.log('🔗 Connexion WebRTC...');
     await webrtcTransport.connect({
@@ -37,7 +49,16 @@ export async function startVoiceAgent(instructions?: string): Promise<OpenAIReal
     });
 
     console.log('✅ Voice Agent connecté avec succès');
-    return webrtcTransport;
+    const remoteStream = getVoiceAgentRemoteStream(webrtcTransport);
+
+    const resolvedLocalStream = (requestedLocalStream as MediaStream | undefined)
+      ?? getLocalStreamFromTransport(webrtcTransport);
+
+    return {
+      transport: webrtcTransport,
+      localStream: resolvedLocalStream ?? null,
+      remoteStream
+    };
 
   } catch (error) {
     console.error('❌ Erreur startVoiceAgent:', error);
@@ -45,13 +66,87 @@ export async function startVoiceAgent(instructions?: string): Promise<OpenAIReal
   }
 }
 
-export function stopVoiceAgent(transport: OpenAIRealtimeWebRTC) {
+export function getVoiceAgentRemoteStream(sessionOrTransport: VoiceAgentSession | OpenAIRealtimeWebRTC): MediaStream | null {
+  const transport = isVoiceAgentSession(sessionOrTransport)
+    ? sessionOrTransport.transport
+    : sessionOrTransport;
+
+  const remoteStream = extractRemoteStream(transport);
+
+  if (isVoiceAgentSession(sessionOrTransport)) {
+    sessionOrTransport.remoteStream = remoteStream;
+  }
+
+  return remoteStream;
+}
+
+export function stopMediaStream(stream?: MediaStream | null) {
+  if (!stream) return;
+
+  stream.getTracks().forEach(track => {
+    try {
+      if (track.readyState !== 'ended') {
+        track.stop();
+      }
+    } catch (error) {
+      console.warn('⚠️ Impossible d\'arrêter une piste média:', error);
+    }
+  });
+}
+
+export function stopVoiceAgent(session: VoiceAgentSession | null) {
+  if (!session) return;
+
   try {
     console.log('🛑 Arrêt Voice Agent...');
-    // La session sera fermée automatiquement lors du démontage du composant
-    // ou via les méthodes internes du transport WebRTC
+
+    stopMediaStream(session.localStream);
+    stopMediaStream(session.remoteStream);
+
+    const transport = session.transport as unknown as {
+      stopLocalMedia?: () => Promise<void> | void;
+      disconnect?: () => Promise<void> | void;
+      close?: () => Promise<void> | void;
+    };
+
+    transport?.stopLocalMedia?.();
+    transport?.disconnect?.();
+    transport?.close?.();
+
     console.log('✅ Voice Agent arrêté');
   } catch (error) {
     console.error('❌ Erreur lors de l\'arrêt:', error);
   }
+}
+
+function isVoiceAgentSession(value: any): value is VoiceAgentSession {
+  return value && typeof value === 'object' && 'transport' in value;
+}
+
+function getLocalStreamFromTransport(transport: OpenAIRealtimeWebRTC): MediaStream | null {
+  const possibleStream = (transport as unknown as { localStream?: MediaStream | null }).localStream;
+  return possibleStream instanceof MediaStream ? possibleStream : null;
+}
+
+function extractRemoteStream(transport: OpenAIRealtimeWebRTC): MediaStream | null {
+  const directRemoteStream = (transport as unknown as { remoteStream?: MediaStream | null }).remoteStream;
+  if (directRemoteStream instanceof MediaStream) {
+    return directRemoteStream;
+  }
+
+  const peerConnection = (transport as unknown as { pc?: RTCPeerConnection; peerConnection?: RTCPeerConnection }).pc
+    ?? (transport as unknown as { pc?: RTCPeerConnection; peerConnection?: RTCPeerConnection }).peerConnection;
+
+  if (!peerConnection) {
+    return null;
+  }
+
+  const aggregatedStream = new MediaStream();
+  peerConnection.getReceivers().forEach(receiver => {
+    if (receiver.track) {
+      aggregatedStream.addTrack(receiver.track);
+    }
+  });
+
+  return aggregatedStream.getTracks().length > 0 ? aggregatedStream : null;
 }


### PR DESCRIPTION
## Summary
- initialize local media in the voice agent SDK, expose session streams, and add helpers for remote media access and cleanup
- update the Sophie agent component to manage microphone/audio refs, bind the remote stream to a hidden audio element, and tear down local tracks when ending a session

## Testing
- npm run lint *(fails: Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@eslint/js' in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2e206431c832c93248cae7c488eda